### PR TITLE
Override entrypoint in build script

### DIFF
--- a/Docker/build_docker.sh
+++ b/Docker/build_docker.sh
@@ -30,7 +30,7 @@ fi
 docker build -f $DOCKER_FILE --tag="$IMAGE_NAME" .
 
 # Run the Docker container and execute the command to check for user bringauto with UID 5000 and GID 5000
-docker run --rm $IMAGE_NAME sh -c 'id -u bringauto 2>/dev/null | grep -q 5000 && id -g bringauto 2>/dev/null | grep -q 5000'
+docker run --entrypoint sh --rm $IMAGE_NAME -c 'id -u bringauto 2>/dev/null | grep -q 5000 && id -g bringauto 2>/dev/null | grep -q 5000'
 if [ $? -ne 0 ]; then
   echo "ERROR: User bringauto with UID 5000 and GID 5000 does not exists in the Docker image. This user is mandatory for SSH agent to work."
   exit 1


### PR DESCRIPTION
At the ned of the build script, dockerfiles with an entrypoint did not have entrypoints overriden in a docker run call.
This would cause the build script to return 1 and teamcity would not push it subsequently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Docker container run command to specify an entrypoint for improved command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->